### PR TITLE
Generate Codecoverage Report

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -40,6 +40,8 @@ jobs:
             name: Code Coverage JSON
             path: regex-ballerina/target/report/test_results.json
             if-no-files-found: ignore
+      - name: Generate CodeCov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,9 @@ jobs:
             name: Code Coverage JSON
             path: regex-ballerina/target/report/test_results.json
             if-no-files-found: ignore  
-
+      - name: Generate CodeCov Report
+        uses: codecov/codecov-action@v1
+        
   windows-build:
 
     runs-on: windows-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,8 @@ jobs:
             name: Code Coverage JSON
             path: regex-ballerina/target/report/test_results.json
             if-no-files-found: ignore  
-      - name: Generate CodeCov Report
+      - name: Generate Codecov Report
+        if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v1
         
   windows-build:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,3 @@ ignore:
 
 codecov:
   require_ci_to_pass: no
-  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+fixes:
+  - "ballerina/regex/*/::regex-ballerina/"
+
+ignore:
+  - "**/tests"
+
+codecov:
+  require_ci_to_pass: no
+  


### PR DESCRIPTION
## Purpose

- Introducing Codecov code coverage report publishing to the `regex` repository

## Goals

- Publishing the testerina generated code coverage xml to Codecov triggered via GitHub action of PR.

## Approach

- A new job is inserted to Pull request and Build GitHub actions that publishes the XML report to Codecov.
- These jobs trigger on push or pull request and CodeCov generates a descriptive code coverage report.
- Codecov also adds comments to any PR made based on the code coverage changes between commits

## Test environment

- Ubuntu 20.04
