### PR TITLE
Update flag for coverage format

### DIFF
--- a/regex-ballerina/build.gradle
+++ b/regex-ballerina/build.gradle
@@ -57,7 +57,7 @@ ballerina {
     packageOrganization = packageOrg
     module = packageName
     langVersion = ballerinaLangVersion
-    testCoverageParam = "--code-coverage --jacoco-xml --includes=ballerina.regex.*"
+    testCoverageParam = "--code-coverage --coverage-format=xml --includes=ballerina.regex.*"
 }
 
 task updateTomlFiles {


### PR DESCRIPTION
## Purpose
Update flag for coverage format from '--jacoco-xml' to '--coverage-format=xml'

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests